### PR TITLE
Fix link to project page in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ django-freeradius
 
 ------------
 
-Django-freeradius is part of the `OpenWISP project <http://openwrt.org>`_.
+Django-freeradius is part of the `OpenWISP project <http://openwisp.org>`_.
 
 .. image:: http://netjsonconfig.openwisp.org/en/latest/_images/openwisp.org.svg
   :target: http://openwisp.org


### PR DESCRIPTION
Link in README.rst goes to OpenWRT and not to OpenWISP.