### PR TITLE
[docs] Improve installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ django-freeradius
 
 ------------
 
-Django-freeradius is part of the `OpenWISP project <http://openwrt.org>`_.
+Django-freeradius is part of the `OpenWISP project <http://openwisp.org>`_.
 
 .. image:: http://netjsonconfig.openwisp.org/en/latest/_images/openwisp.org.svg
   :target: http://openwisp.org

--- a/docs/source/general/freeradius.rst
+++ b/docs/source/general/freeradius.rst
@@ -19,7 +19,7 @@ First of all, become root:
     sudo -i
 
 .. note::
-    If you use a recent version of Debian like **Jessie** or Ubuntu **Zesty**,
+    If you use a recent version of Debian like **Stretch** (9) or Ubuntu **Zesty** (17),
     you can skip the following command and use the official repositories if you prefer.
 
 Let's add the PPA repository for the Freeradius 3.x stable branch:
@@ -64,8 +64,12 @@ Now enable the ``sql`` and ``rest`` modules:
 .. code-block:: shell
 
     cd mods-enabled/
-    ln -s /etc/freeradius/mods-available/sql /etc/freeradius/mods-enabled/sql
-    ln -s /etc/freeradius/mods-available/rest /etc/freeradius/mods-enabled/rest
+    ln -s /etc/freeradius/3.0/mods-available/sql /etc/freeradius/3.0/mods-enabled/sql
+    ln -s /etc/freeradius/3.0/mods-available/rest /etc/freeradius/3.0/mods-enabled/rest
+    
+.. note::
+    Where *3.0* is version of freeradius. In the future there may be another version, not 3.0.
+    And on some distributions the *3.0/* dir is missing and then typically the path is `/etc/freeradius/mods-available`
 
 Restart freeradius to load the new configuration:
 

--- a/docs/source/general/setup.rst
+++ b/docs/source/general/setup.rst
@@ -2,6 +2,23 @@
 Setup
 =====
 
+Create a virtual environment
+----------------------------
+
+Please use a `python virtual environment <https://docs.python.org/3/library/venv.html>`_. It keeps everybody on the same page, helps reproducing bugs
+and resolving problems. Otherwise, you may encounter errors.
+
+We suggest you to use `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io>`_ for this task.
+
+.. code-block:: shell
+
+    mkvirtualenv radius  # create virtualenv
+
+.. note::
+    You may encounter an error like `Python could not import the module virtualenvwrapper`
+    **Solution**: enter `VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3` and run `source virtualenvwrapper.sh` again :)
+
+
 Install stable version from pypi
 --------------------------------
 
@@ -72,6 +89,12 @@ Install sqlite:
 .. code-block:: shell
 
     sudo apt-get install sqlite3 libsqlite3-dev
+
+Install mysqlclient:
+
+.. code-block:: shell
+
+    sudo apt-get install libmysqlclient-dev
 
 Install your forked repo:
 

--- a/docs/source/general/setup.rst
+++ b/docs/source/general/setup.rst
@@ -5,19 +5,19 @@ Setup
 Create a virtual environment
 ----------------------------
 
-Please use a `python virtual environment <https://docs.python.org/3/library/venv.html>`_. It keeps everybody on the same page, helps reproducing bugs
-and resolving problems. Otherwise, you may encounter errors.
+Please use a `python virtual environment <https://docs.python.org/3/library/venv.html>`_.
+It keeps everybody on the same page, helps reproducing bugs and resolving problems.
 
-We suggest you to use `virtualenvwrapper <https://virtualenvwrapper.readthedocs.io>`_ for this task.
+We highly suggest to use **virtualenvwrapper**, please refer to the official `virtualenvwarpper installation page <http://virtualenvwrapper.readthedocs.io/en/latest/install.html>`_ and come back here when ready to proceed.
 
 .. code-block:: shell
 
-    mkvirtualenv radius  # create virtualenv
+    # create virtualenv
+    mkvirtualenv radius
 
 .. note::
-    You may encounter an error like `Python could not import the module virtualenvwrapper`
-    **Solution**: enter `VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3` and run `source virtualenvwrapper.sh` again :)
-
+    If you encounter an error like ``Python could not import the module virtualenvwrapper``
+    add ``VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3`` and run ``source virtualenvwrapper.sh`` again :)
 
 Install stable version from pypi
 --------------------------------


### PR DESCRIPTION
`anom@ubuntu:~/django-freeradius$ python3 setup.py develop`
The following error occurred while trying to add or remove files in the
installation directory:
    [Errno 13] Permission denied: '/usr/local/lib/python3.5/dist-packages/test-easy-install-95996.pth'
...
Perhaps your account does not have write access to this directory?  If the
installation directory is a system-owned directory, you may need to sign in
as the administrator or "root" account.  If you do not have administrative
access to this machine, you may wish to choose a different installation
directory, preferably one that is listed in your PYTHONPATH environment
variable.
So for fixing that I had to use `sudo` (*sudo python3 setup.py develop*)

After `pip3 install -r requirements-test.txt` I have got a lot of problems of installing like on my 2/3 VM's
*PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.5/dist-packages/coverage*
*PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.5/dist-packages/docopt.py'*

References and closes #75. 
