### PR TITLE
[admin] Add link to CSV import docs

### DIFF
--- a/django_freeradius/base/forms.py
+++ b/django_freeradius/base/forms.py
@@ -60,3 +60,11 @@ class AbstractRadiusBatchAdminForm(forms.ModelForm):
     number_of_users = forms.IntegerField(required=False,
                                          validators=[MinValueValidator(1)],
                                          help_text=_('Number of users to be generated'))
+
+    def __init__(self, *args, **kwargs):
+        super(AbstractRadiusBatchAdminForm, self).__init__(*args, **kwargs)
+        if self.fields.get('csvfile'):
+            docs_link = "https://django-freeradius.readthedocs.io/en/latest/general/importing_users.html"
+            help_text = "Refer to the <b><u><a href='{}'>docs</a></u></b> for more \
+                details on importing users from a CSV".format(docs_link)
+            self.fields['csvfile'].help_text = help_text

--- a/django_freeradius/tests/base/test_admin.py
+++ b/django_freeradius/tests/base/test_admin.py
@@ -268,3 +268,9 @@ class BaseTestAdmin(object):
         response = self.client.post(changelist_path, data, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(User.objects.count() - n, 0)
+
+    def test_radius_batch_csv_help_text(self):
+        add_url = reverse('admin:{0}_radiusbatch_add'.format(self.app_name))
+        response = self.client.get(add_url)
+        docs_link = "https://django-freeradius.readthedocs.io/en/latest/general/importing_users.html"
+        self.assertContains(response, docs_link)


### PR DESCRIPTION
Using the help_text as "Refer to the [docs](https://django-freeradius.readthedocs.io/en/latest/general/importing_users.html) for more details on importing users from a CSV".