### PR TITLE
[api] Made auth_header in test_api an attribute for better reuse

### DIFF
--- a/django_freeradius/tests/test_api.py
+++ b/django_freeradius/tests/test_api.py
@@ -5,6 +5,8 @@ import swapper
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from django_freeradius import settings as app_settings
+
 from . import ApiParamsMixin, CreateRadiusObjectsMixin
 from .base.test_api import BaseTestApi, BaseTestApiReject
 
@@ -19,8 +21,9 @@ class TestApi(BaseTestApi, TestCase, CreateRadiusObjectsMixin, ApiParamsMixin):
     radius_accounting_model = RadiusAccounting
     radius_batch_model = RadiusBatch
     user_model = get_user_model()
+    auth_header = "Bearer {}".format(app_settings.API_TOKEN)
 
 
 @skipIf(os.environ.get('SAMPLE_APP', False), 'Running tests on SAMPLE_APP')
 class TestApiReject(BaseTestApiReject, TestCase, CreateRadiusObjectsMixin):
-    pass
+    auth_header = "Bearer {}".format(app_settings.API_TOKEN)

--- a/tests/sample_radius/tests.py
+++ b/tests/sample_radius/tests.py
@@ -2,6 +2,7 @@ import os
 from unittest import skipUnless
 
 import swapper
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
@@ -116,6 +117,7 @@ class TestApi(BaseTestApi, TestCase, CreateRadiusObjectsMixin, ApiParamsMixin):
     radius_accounting_model = RadiusAccounting
     radius_batch_model = RadiusBatch
     user_model = get_user_model()
+    auth_header = "Bearer {}".format(settings.DJANGO_FREERADIUS_API_TOKEN)
 
 
 @skipUnless(os.environ.get('SAMPLE_APP', False), 'Running tests on standard django_freeradius models')
@@ -139,4 +141,4 @@ class TestUtils(BaseTestUtils, TestCase, CreateRadiusObjectsMixin, FileMixin):
 
 @skipUnless(os.environ.get('SAMPLE_APP', False), 'Running tests on standard django_freeradius models')
 class TestApiReject(BaseTestApiReject, TestCase, CreateRadiusObjectsMixin):
-    pass
+    auth_header = "Bearer {}".format(settings.DJANGO_FREERADIUS_API_TOKEN)


### PR DESCRIPTION
For openwisp-radius's tests, there needs to be a dynamic value for ```auth_header``` and this allows for it as the ```auth_header``` is set when the tests are inherited and run.