### PR TITLE
[admin] Remove redundant condition check

### DIFF
--- a/django_freeradius/base/admin.py
+++ b/django_freeradius/base/admin.py
@@ -298,7 +298,7 @@ class AbstractRadiusBatchAdmin(TimeStampedEditableAdmin):
         strategy = data.get('strategy')
         if not change:
             if strategy == "csv":
-                if data.get('csvfile', False) and not change:
+                if data.get('csvfile', False):
                     csvfile = data.get('csvfile')
                     obj.csvfile_upload(csvfile)
             elif strategy == "prefix":


### PR DESCRIPTION
"and not change" is removed because the condition change is already being tested on line 299. 
This is redundant and removing it improves code quality.

Tests pass, although `./runflake8` complains about unrelated errors in `settings.py`.