### PR TITLE
[settings] Improve default for batch mail sender #179

### DIFF
--- a/django_freeradius/settings.py
+++ b/django_freeradius/settings.py
@@ -22,7 +22,7 @@ BATCH_DEFAULT_PASSWORD_LENGTH = getattr(settings, 'DJANGO_FREERADIUS_BATCH_DEFAU
 BATCH_DELETE_EXPIRED = getattr(settings, 'DJANGO_FREERADIUS_BATCH_DELETE_EXPIRED', 18)
 BATCH_MAIL_SUBJECT = getattr(settings, 'DJANGO_FREERADIUS_BATCH_MAIL_SUBJECT', 'Credentials')
 BATCH_MAIL_MESSAGE = getattr(settings, 'DJANGO_FREERADIUS_BATCH_MAIL_MESSAGE', 'username: {}, password: {}')
-BATCH_MAIL_SENDER = getattr(settings, 'DJANGO_FREERADIUS_BATCH_MAIL_SENDER', 'testing@localhost')
+BATCH_MAIL_SENDER = getattr(settings, 'DJANGO_FREERADIUS_BATCH_MAIL_SENDER', settings.DEFAULT_FROM_EMAIL)
 BATCH_PDF_TEMPLATE = getattr(settings,
                              'DJANGO_FREERADIUS_BATCH_PDF_TEMPLATE',
                              os.path.join(os.path.dirname(__file__),

--- a/docs/source/general/importing_users.rst
+++ b/docs/source/general/importing_users.rst
@@ -89,3 +89,5 @@ The text could be anything but should have the format string operators ``{}`` fo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is the sender email which is also to be configured in the SMTP settings.
+The default sender email is a common setting from the `Django core settings  <https://docs.djangoproject.com/en/2.1/ref/settings/#default-from-email>`_ under ``DEFAULT_FROM_EMAIL``.
+Currently, ``DEFAULT_FROM_EMAIL`` is set to to ``webmaster@localhost``.


### PR DESCRIPTION
Changes DJANGO_FREERADIUS_BATCH_MAIL_SENDER from "testing@localhost" to DEFAULT_FROM_EMAIL from the Django docs. 
DEFAULT_FROM_EMAIL is equal to "webmaster@localhost". 
Instead of setting the value directly, I chose to use this variable because it will be changed dynamically in the future.

Closes #179