### PR TITLE
[api] Improve robustness of TokenAuthentication #182

### DIFF
--- a/django_freeradius/api/views.py
+++ b/django_freeradius/api/views.py
@@ -7,7 +7,7 @@ from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics, status
 from rest_framework.authentication import BaseAuthentication
-from rest_framework.exceptions import AuthenticationFailed, ValidationError
+from rest_framework.exceptions import AuthenticationFailed, ParseError, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -28,7 +28,10 @@ class TokenAuthentication(BaseAuthentication):
         if request.META.get('HTTP_AUTHORIZATION', False):
             headers = request.META.get('HTTP_AUTHORIZATION').split(',')
             for header in headers:
-                token = header.split(' ')[1]
+                try:
+                    token = header.split(' ')[1]
+                except IndexError:
+                    raise ParseError('Invalid token')
                 if token == app_settings.API_TOKEN:
                     return (AnonymousUser(), None)
         if request.GET.get('token') == app_settings.API_TOKEN:

--- a/django_freeradius/tests/base/test_api.py
+++ b/django_freeradius/tests/base/test_api.py
@@ -15,6 +15,15 @@ User = get_user_model()
 
 
 class BaseTestApi(object):
+    def test_valid_token(self):
+        options = dict(username='molly', password='barbar')
+        self._create_user(**options)
+        auth_header = self.auth_header.replace(' ', '')  # removes spaces in token
+        response = self.client.post(reverse('freeradius:authorize'),
+                                    {'username': 'molly', 'password': 'barbar'},
+                                    HTTP_AUTHORIZATION=auth_header)
+        self.assertEqual(response.status_code, 400)
+
     def test_disabled_user_login(self):
         options = dict(username='barbar', password='molly', is_active=False)
         self._create_user(**options)


### PR DESCRIPTION
Tests works fine if the authorization header is in the standard format `Authorization: <Type> <Credentials>` but would fail if there is no space in between type and credentials.

Fixes #182