### PR TITLE
[accounting API] automatically fill in groupname 

### DIFF
--- a/django_freeradius/settings.py
+++ b/django_freeradius/settings.py
@@ -32,3 +32,4 @@ API_AUTHORIZE_REJECT = getattr(settings, 'DJANGO_FREERADIUS_API_AUTHORIZE_REJECT
 SOCIAL_LOGIN_ENABLED = {'allauth.socialaccount',
                         'rest_framework.authtoken'}.issubset(settings.INSTALLED_APPS)
 DISPOSABLE_USER_TOKEN = getattr(settings, 'DJANGO_FREERADIUS_DISPOSABLE_USER_TOKEN', True)
+API_ACCOUNTING_AUTO_GROUP = getattr(settings, 'DJANGO_FREERADIUS_API_ACCOUNTING_AUTO_GROUP', True)

--- a/django_freeradius/tests/test_api.py
+++ b/django_freeradius/tests/test_api.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 
 from . import CreateRadiusObjectsMixin, PostParamsMixin
 from .. import settings as app_settings
+from ..models import RadiusUserGroup
 from .base.test_api import BaseTestApi, BaseTestApiReject
 
 RadiusPostAuth = swapper.load_model('django_freeradius', 'RadiusPostAuth')
@@ -24,11 +25,72 @@ class TestApi(BaseTestApi, ApiTestCase):
     radius_accounting_model = RadiusAccounting
     radius_batch_model = RadiusBatch
     user_model = get_user_model()
+    radius_usergroup_model = RadiusUserGroup
     auth_header = 'Bearer {}'.format(app_settings.API_TOKEN)
     token_querystring = '?token={}'.format(app_settings.API_TOKEN)
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestApi, cls).setUpClass()
+        app_settings.API_ACCOUNTING_AUTO_GROUP = True
+
+    def test_automatic_groupname_account_enabled(self):
+        user = self.user_model.objects.create_superuser(
+            username='username1', email='admin@admin.com', password='qwertyuiop'
+        )
+        usergroup1 = self._create_radius_usergroup(groupname='group1', priority=2, username='testgroup1')
+        usergroup2 = self._create_radius_usergroup(groupname='group2', priority=1, username='testgroup2')
+        user.radiususergroup_set.set([usergroup1, usergroup2])
+        self.client.post('/api/v1/accounting/{}'.format(self.token_querystring), {
+            'status_type': 'Start',
+            'session_time': '',
+            'input_octets': '',
+            'output_octets': '',
+            'nas_ip_address': '127.0.0.1',
+            'session_id': '48484',
+            'unique_id': '1515151',
+            'username': 'username1',
+        })
+        accounting_created = self.radius_accounting_model.objects.get(username='username1')
+        self.assertEquals(accounting_created.groupname, 'group2')
+        user.delete()
 
 
 @skipIf(os.environ.get('SAMPLE_APP', False), 'Running tests on SAMPLE_APP')
 class TestApiReject(BaseTestApiReject, ApiTestCase):
     auth_header = 'Bearer {}'.format(app_settings.API_TOKEN)
     token_querystring = '?token={}'.format(app_settings.API_TOKEN)
+
+
+class TestAutomaticGroupnameSetting(ApiTestCase):
+    radius_accounting_model = RadiusAccounting
+    user_model = get_user_model()
+    radius_usergroup_model = RadiusUserGroup
+    auth_header = 'Bearer {}'.format(app_settings.API_TOKEN)
+    token_querystring = '?token={}'.format(app_settings.API_TOKEN)
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAutomaticGroupnameSetting, cls).setUpClass()
+        app_settings.API_ACCOUNTING_AUTO_GROUP = False
+
+    def test_account_creation_api_automatic_groupname_disabled(self):
+        user = self.user_model.objects.create_superuser(
+            username='username1', email='admin@admin.com', password='qwertyuiop'
+        )
+        usergroup1 = self._create_radius_usergroup(groupname='group1', priority=2, username='testgroup1')
+        usergroup2 = self._create_radius_usergroup(groupname='group2', priority=1, username='testgroup2')
+        user.radiususergroup_set.set([usergroup1, usergroup2])
+        self.client.post('/api/v1/accounting/{}'.format(self.token_querystring), {
+            'status_type': 'Start',
+            'session_time': '',
+            'input_octets': '',
+            'output_octets': '',
+            'nas_ip_address': '127.0.0.1',
+            'session_id': '48484',
+            'unique_id': '1515151',
+            'username': 'username1',
+        })
+        accounting_created = self.radius_accounting_model.objects.get(username='username1')
+        self.assertIsNone(accounting_created.groupname)
+        user.delete()

--- a/docs/source/general/settings.rst
+++ b/docs/source/general/settings.rst
@@ -180,3 +180,12 @@ The text could be anything but should have the format string operator ``{}`` for
 It is the sender email which is also to be configured in the SMTP settings.
 The default sender email is a common setting from the `Django core settings  <https://docs.djangoproject.com/en/2.1/ref/settings/#default-from-email>`_ under ``DEFAULT_FROM_EMAIL``.
 Currently, ``DEFAULT_FROM_EMAIL`` is set to to ``webmaster@localhost``.
+
+``DJANGO_FREERADIUS_API_ACCOUNTING_AUTO_GROUP``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Default**: ``True``
+
+When this setting is enabled, every accounting instance saved from the API will have its ``groupname`` attribute automatically filled in.
+The value filled in will be the ``groupname`` of the ``RadiusUserGroup`` of the highest priority among the RadiusUserGroups related to the user with the ``username`` as in the accounting instance.
+In the event there is no user in the database corresponding to the ``username`` in the accounting instance, the failure will be logged with `info` level but the accounting will be saved as usual.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -167,3 +167,4 @@ try:
     from local_settings import *
 except ImportError:
     pass
+DJANGO_FREERADIUS_API_ACCOUNTING_AUTO_GROUP = True


### PR DESCRIPTION
for accounting instance when saved from API

The groupname is of the group with the highest priority related to the user
Fixes #185