### PR TITLE
[qa] Install flake8 and isort via openwisp-utils[qa]

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,5 @@
 coverage
 coveralls
-isort
-flake8
 django-environ
 mysqlclient
 psycopg2
@@ -11,4 +9,4 @@ freezegun
 django-extensions
 django-rest-auth>=0.9.3,<0.12.0
 django-allauth>=0.36.0,<0.39.0
-openwisp-utils>=0.2.1
+openwisp-utils[qa]>=0.2.1


### PR DESCRIPTION
Install `flake8` and `isort` via `openwisp-utils[qa]`.