### PR TITLE
[docs] Add management commands suggestion in the setup page #171

### DIFF
--- a/docs/source/general/management_commands.rst
+++ b/docs/source/general/management_commands.rst
@@ -10,7 +10,7 @@ Example usage:
 .. code-block:: shell
 
     cd tests/
-    ./manage.py <commad> <args>
+    ./manage.py <command> <args>
 
 In this page we list the management commands currently available in **django-freeradius**.
 

--- a/docs/source/general/setup.rst
+++ b/docs/source/general/setup.rst
@@ -169,3 +169,56 @@ Run tests with:
 .. code-block:: shell
 
     ./runtests.py
+
+Automating management commands
+------------------------------
+
+Some management commands are necessary to enable certain
+features and also facilitate database cleanup. In a
+production environment, it is highly recommended to 
+automate the usage of these commands by using cron jobs.
+
+Edit the crontab with:
+
+.. code-block:: shell
+
+    crontab -e
+
+Add and modify the following lines accordingly:
+
+.. code-block:: shell
+
+    # This command deletes RADIUS accounting sessions older than 365 days
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py delete_old_radacct 365
+
+    # This command deletes RADIUS post-auth logs older than 365 days
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py delete_old_postauth 365
+
+    # This command closes stale RADIUS sessions that have remained open for 15 days
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py cleanup_stale_radacct 15
+
+    # This command deactivates expired user accounts which were created temporarily
+    # (eg: for en event) and have an expiration date set.
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py deactivate_expired_users
+
+    # This command deletes users that have expired (and should have 
+    # been deactivated by deactivate_expired_users) for more than 
+    # 18 months (which is the default duration)
+    30 04 * * * <virtualenv_path>/bin/python <full/path/to>/manage.py delete_old_users
+
+Be sure to replace ``<virtualenv_path>`` with the full path to the Python
+virtual environment. 
+
+Also, change ``<full/path/to>`` to the directory where ``manage.py`` is.
+
+To get the full path to ``manage.py`` when django-freeradius is 
+installed for development, navigate to the base directory of 
+the cloned fork. Then, run:
+
+.. code-block:: shell
+    
+    cd tests/
+    pwd
+
+More information can be found at the 
+`management commands page <./management_commands.html>`_.


### PR DESCRIPTION
A suggestion is made in the setup page to automate the usage of the management commands. A sample crontab is also added.