### PR TITLE
[docs] Specifies user to keep the django server running #223

### DIFF
--- a/docs/source/general/freeradius.rst
+++ b/docs/source/general/freeradius.rst
@@ -283,6 +283,11 @@ Restart freeradius to load the new configuration:
     # alternatively if you are using systemd
     systemctl restart freeradius
 
+In case of any error, run ``journalctl -xe`` to know the cause. You can also run ``freeradius -X`` to know the 
+detailed cause. One error might be that the django-freeradius server might not be running in the background.
+To set up the django-freeradius server refer `this <https://django-freeradius.readthedocs.io/en/latest/general/setup.html#installing-for-development>`_
+Also make sure that this server runs on the port specified in ``/etc/freeradius/mods-enabled/rest``.
+
 You may also want to take a look at the `Freeradius documentation <http://freeradius.org/doc/>`_
 for further details on how to configure other modules.
 


### PR DESCRIPTION
The docs currently assume that the user is running the django-freeradius server in the background. Since the docs did not have any instances of pointing that, this commit will make the doc mention clearly the need to keep the django-freeradius server running in the background while attempting to start the freeradius server with the config changes specified in the docs. Fixes #223