### PR TITLE
[gitignore] Updated gitignore file to proposed standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,36 @@
+### Project Specifics ###
+tests/.env
+
+### other ###
+*.DS_Store*
+*~
+._*
+*.tar.gz
+
+### editors ###
+*.komodoproject
+.vscode/
+.idea/
+
+# Created by https://www.gitignore.io/api/venv,django
+# Edit at https://www.gitignore.io/?templates=venv,django
+
+### Django ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+*.db
+media/
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+*$py.class
 *.swp
 
 # C extensions
@@ -8,24 +38,26 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
 downloads/
 eggs/
-/lib/
+.eggs/
+lib/
 lib64/
 parts/
 sdist/
 var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -36,17 +68,22 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
 *.pot
 
-# Django stuff:
-*.log
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
@@ -54,18 +91,60 @@ docs/_build/
 # PyBuilder
 target/
 
-# editors
-*.komodoproject
+# pyenv
+.python-version
 
-# other
-*.DS_Store*
-*~
-._*
-local_settings.py
-*.db
-*.tar.gz
-tests/.env
-media/
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
 
-#Pycharm projects
-.idea/
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### venv ###
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pip-selfcheck.json
+
+# End of https://www.gitignore.io/api/venv,django


### PR DESCRIPTION
Added vitualenv specific directories to gitignore along with formatting gitignore in new propsed standard.

New standard for gitgnore for Python/Django projects proposes to have ignores in following order :

| Categories | Description |
| ------------- | ------------- |
| Project specifics   | Files/directories which are specific to a project.  |
| Django ignores  | Conventional Django ignores  |
| Python ignores | Conventional Python ignores |
| Virtual environment ignores | Possible name of directories used for creating virtual environment |
| Other | OS related and other ignores |
| Editor ignores | Directories containing IDE or editor configurations.  |

`Conventional ignores` refers to ignores included in `.gitignore` generated by [gitignore.io](gitignore.io) which I have assumed to be standard in their domains.

If approved, this format will be used for other Python project repositories of OpenWisp also.