### PR TITLE
[ci] Remove deprecated Travis key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 
 cache: pip
 


### PR DESCRIPTION
This pull request removes reference to deprecated Travis CI `sudo: true`, as per https://config.travis-ci.com/explore.
Google Code-in Link: https://codein.withgoogle.com/dashboard/task-instances/4534193363615744/

This is Code-in user aaPle.
