### PR TITLE
[Improvement] Migrate html2pdf to weasyprint

### DIFF
--- a/django_freeradius/templates/django_freeradius/prefix_pdf.html
+++ b/django_freeradius/templates/django_freeradius/prefix_pdf.html
@@ -1,20 +1,30 @@
-<!DOCTYPE html>{% load static %}
+<!DOCTYPE html>{% load i18n %}
 <html>
 <head>
-    {% block style %}
-	<link href="{% static 'django-freeradius/css/freeradius.css' %}" rel="stylesheet" />
-    {% endblock %}
+    <title>{% trans 'WiFi username and passwords' %}</title>
+    <style type="text/css">
+        body {
+            font-size: 15px;
+            font-family: sans-serif
+        }
+        table { width: 100%; border-collapse: collapse }
+        table th { font-weight: bold }
+        table th, table td {
+            border: 1px solid #ccc;
+            padding: 10px;
+        }
+    </style>
 </head>
 <body>
 <table>
     <tr>
-        <th>Username</th>
-        <th>Password</th>
+        <th>{% trans 'Username' %}</th>
+        <th>{% trans 'Password' %}</th>
     </tr>
-    {% for u in users %}
+    {% for row in users %}
     <tr>
-	{% for x in u %}
-        <td>{{ x }}</td>
+	{% for cell in row %}
+        <td>{{ cell }}</td>
 	{% endfor %}
     </tr>
     {% endfor %}

--- a/django_freeradius/utils.py
+++ b/django_freeradius/utils.py
@@ -10,7 +10,7 @@ from django.core.validators import validate_email
 from django.template.loader import get_template
 from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
-from xhtml2pdf import pisa
+from weasyprint import HTML
 
 from django_freeradius.settings import BATCH_PDF_TEMPLATE
 
@@ -72,9 +72,9 @@ def prefix_generate_users(prefix, n, password_length):
 
 def generate_pdf(prefix, data):
     template = get_template(BATCH_PDF_TEMPLATE)
-    html = template.render(data)
+    html = HTML(string=template.render(data))
     f = open("{}/{}.pdf".format(settings.MEDIA_ROOT, prefix), "w+b")
-    pisa.CreatePDF(html.encode("utf-8"), dest=f, encoding="utf-8")
+    html.write_pdf(target=f)
     f.seek(0)
     return File(f)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ djangorestframework>=3.8.2,<3.10.0
 passlib>=1.7.1,<1.8.0
 django-filter>=2.1.0,<2.2.0
 djangorestframework-link-header-pagination>=0.1.1,<0.2.0
-xhtml2pdf>=0.2.3,<0.3.0
+weasyprint>=43,<51


### PR DESCRIPTION
PR for improvement commit, which makes a migration from html2pdf to weasyprint. Changes:
 - Adds `weasyprint>=44` to requirements.txt instead of `xmtml2pdf`
 - Changes `STATIC_URL` in tests/settings.py to compatible with weasyprint
 - Creates `BATCH_PDF_TEMPLATE_BASE_URL` in django_freeradius/settings.py
 - Changes `generate_pdf` function in django_freeradius/utils.py, now it works using weasyprint API

Closes #243