### PR TITLE
[ci] Implicitly get coverage version from coverage

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-coverage
 coveralls
 django-environ
 mysqlclient


### PR DESCRIPTION
The coveralls package already has a dependency on coverage
and sets the boundary according to its support for the coverage library.
We should not duplicate this information.