### PR TITLE
[docs] Add step to install Weasy Print #261

### DIFF
--- a/docs/source/general/setup.rst
+++ b/docs/source/general/setup.rst
@@ -18,6 +18,15 @@ We highly suggest to use **virtualenvwrapper**, please refer to the official `vi
 .. note::
     If you encounter an error like ``Python could not import the module virtualenvwrapper``, 
     add ``VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3`` and run ``source virtualenvwrapper.sh`` again :)
+    
+Install required system packages
+--------------------------------
+
+Install packages required by Weasyprint for your OS:
+
+ - `Linux <https://weasyprint.readthedocs.io/en/stable/install.html#linux>`_
+ - `MacOS <https://weasyprint.readthedocs.io/en/stable/install.html#macos>`_
+ - `Windows <https://weasyprint.readthedocs.io/en/stable/install.html#windows>`_
 
 Install stable version from pypi
 --------------------------------


### PR DESCRIPTION
This is a PR for commit which adds links to additional info about installation of WeasyPrint for different OS to `Install stable version from pypi`, `Install development version` and `Installing for development` sections of `setup.rst`.

##### Other possible implementation variants:
 - Create a section for WeasyPrint installation and link to this section in each installation variant

Please mention if some other enchancements / variants should be implemented

Fixes #261